### PR TITLE
feat(video): prefer locally saved videos; enrich status endpoint; remove by-job route

### DIFF
--- a/components/ai/video.tsx
+++ b/components/ai/video.tsx
@@ -28,6 +28,10 @@ export function VideoJob({ jobId }: VideoJobProps) {
         if (cancelled) return
         setStatus(String(data.status || 'queued'))
         setProgress(Number.isFinite(data.progress) ? Number(data.progress) : 0)
+        if (typeof data.url === 'string' && data.url) {
+          setUrl(data.url)
+          return
+        }
         // Upstream moderation or provider errors (surface and stop polling)
         const jobError = (data?.job && typeof data.job === 'object') ? (data.job as any).error : null
         if (jobError && (jobError.message || jobError.code)) {

--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -370,15 +370,20 @@ export default function ChatMessages({
               if (latestVideoPart) {
                 const out = latestVideoPart?.output
                 const url: string | undefined = (out && typeof out.url === 'string' && out.url) ? out.url : undefined
-                if (url) {
+                const jobId: string | undefined = (out?.details?.job?.id as string) || undefined
+                // Prefer local files; ignore remote API URLs
+                if (url && url.startsWith('/')) {
                   return (
                     <div className="mb-3 rounded-lg overflow-hidden border max-w-[1024px]">
                       <video src={url} controls className="w-full h-auto" />
                     </div>
                   )
                 }
+                // If the tool provided a remote URL, fall back to VideoJob to resolve the local saved asset
+                if (url && jobId) {
+                  return <VideoJob jobId={jobId} />
+                }
                 // Poll job status while queued
-                const jobId: string | undefined = (out?.details?.job?.id as string) || undefined
                 if (jobId) {
                   return <VideoJob jobId={jobId} />
                 }

--- a/lib/modules/tools/video-generation/video.service.ts
+++ b/lib/modules/tools/video-generation/video.service.ts
@@ -33,38 +33,6 @@ async function getVideoDefaults(): Promise<{ model: string; size: string; second
   }
 }
 
-function pickContentExt(contentType: string | null | undefined): string {
-  const ct = String(contentType || '').toLowerCase()
-  if (ct.includes('webm')) return 'webm'
-  if (ct.includes('quicktime') || ct.includes('mov')) return 'mov'
-  if (ct.includes('m4v')) return 'm4v'
-  return 'mp4'
-}
-
-function extractVideoUrl(json: any): string | null {
-  if (!json || typeof json !== 'object') return null
-  if (json.assets && typeof json.assets === 'object') {
-    if (typeof json.assets.video === 'string' && json.assets.video) return json.assets.video
-    if (Array.isArray(json.assets) && json.assets.length > 0) {
-      const first = json.assets.find((a: any) => typeof a?.video === 'string')
-      if (first?.video) return String(first.video)
-    }
-  }
-  if (typeof json.url === 'string' && json.url) return json.url
-  if (json.data && Array.isArray(json.data) && json.data[0]?.url) return String(json.data[0].url)
-  const maybeContent = json.output || json.contents || json.content
-  const arr = Array.isArray(maybeContent) ? maybeContent : []
-  for (const item of arr) {
-    const blocks = Array.isArray(item?.content) ? item.content : []
-    for (const b of blocks) {
-      if (b?.type === 'output_video' && typeof b?.video?.url === 'string') return b.video.url
-      if (b?.type === 'video' && typeof b?.video?.url === 'string') return b.video.url
-      if (typeof b?.url === 'string') return b.url
-    }
-  }
-  return null
-}
-
 export class VideoGenerationService {
   static async generateWithOpenAI(userId: string, input: VideoGenerationInput): Promise<VideoGenerationResult> {
     const defaults = await getVideoDefaults()


### PR DESCRIPTION
Summary
- Use locally saved videos in chat instead of expiring provider URLs.
- Enrich GET /api/v1/videos/sora2/{id}/status to include local { url, fileId } when available.
- Update VideoJob to prefer the status-provided local URL and finalize only when needed.
- Update ChatMessages to avoid remote video URLs and rely on VideoJob/local file.
- Remove the temporary /api/v1/videos/sora2/by-job/{id} endpoint.

Changes
- app/api/v1/videos/sora2/[id]/status/route.ts: include local url/fileId if a saved file exists for jobId.
- components/ai/video.tsx: consume data.url from status; fallback to finalize; better error handling.
- components/chat/chat-messages.tsx: ignore remote URLs; render VideoJob or local /files path.
- Deleted app/api/v1/videos/sora2/by-job/[id]/route.ts.

API Docs
- Swagger blocks updated on status route to reflect returned fields.

Security
- Routes re-authorize via auth() and validate inputs.
- No GET-side effects except status; finalize remains POST.

Backward compatibility
- UI continues to work; removed /by-job route was internal and is no longer used.

Testing
- Trigger video generation.
- Observe VideoJob polling; once done, status returns url and the video plays from /files/... without expiring.
- Verify /swagger shows the updated status schema.