### PR TITLE
Video generation: show locally saved video in chat; enrich status endpoint

### DIFF
--- a/components/ai/video.tsx
+++ b/components/ai/video.tsx
@@ -28,6 +28,10 @@ export function VideoJob({ jobId }: VideoJobProps) {
         if (cancelled) return
         setStatus(String(data.status || 'queued'))
         setProgress(Number.isFinite(data.progress) ? Number(data.progress) : 0)
+        if (typeof data.url === 'string' && data.url) {
+          setUrl(data.url)
+          return
+        }
         // Upstream moderation or provider errors (surface and stop polling)
         const jobError = (data?.job && typeof data.job === 'object') ? (data.job as any).error : null
         if (jobError && (jobError.message || jobError.code)) {

--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -370,15 +370,20 @@ export default function ChatMessages({
               if (latestVideoPart) {
                 const out = latestVideoPart?.output
                 const url: string | undefined = (out && typeof out.url === 'string' && out.url) ? out.url : undefined
-                if (url) {
+                const jobId: string | undefined = (out?.details?.job?.id as string) || undefined
+                // Prefer local files; ignore remote API URLs
+                if (url && url.startsWith('/')) {
                   return (
                     <div className="mb-3 rounded-lg overflow-hidden border max-w-[1024px]">
                       <video src={url} controls className="w-full h-auto" />
                     </div>
                   )
                 }
+                // If the tool provided a remote URL, fall back to VideoJob to resolve the local saved asset
+                if (url && jobId) {
+                  return <VideoJob jobId={jobId} />
+                }
                 // Poll job status while queued
-                const jobId: string | undefined = (out?.details?.job?.id as string) || undefined
                 if (jobId) {
                   return <VideoJob jobId={jobId} />
                 }

--- a/lib/modules/tools/video-generation/video.service.ts
+++ b/lib/modules/tools/video-generation/video.service.ts
@@ -33,38 +33,6 @@ async function getVideoDefaults(): Promise<{ model: string; size: string; second
   }
 }
 
-function pickContentExt(contentType: string | null | undefined): string {
-  const ct = String(contentType || '').toLowerCase()
-  if (ct.includes('webm')) return 'webm'
-  if (ct.includes('quicktime') || ct.includes('mov')) return 'mov'
-  if (ct.includes('m4v')) return 'm4v'
-  return 'mp4'
-}
-
-function extractVideoUrl(json: any): string | null {
-  if (!json || typeof json !== 'object') return null
-  if (json.assets && typeof json.assets === 'object') {
-    if (typeof json.assets.video === 'string' && json.assets.video) return json.assets.video
-    if (Array.isArray(json.assets) && json.assets.length > 0) {
-      const first = json.assets.find((a: any) => typeof a?.video === 'string')
-      if (first?.video) return String(first.video)
-    }
-  }
-  if (typeof json.url === 'string' && json.url) return json.url
-  if (json.data && Array.isArray(json.data) && json.data[0]?.url) return String(json.data[0].url)
-  const maybeContent = json.output || json.contents || json.content
-  const arr = Array.isArray(maybeContent) ? maybeContent : []
-  for (const item of arr) {
-    const blocks = Array.isArray(item?.content) ? item.content : []
-    for (const b of blocks) {
-      if (b?.type === 'output_video' && typeof b?.video?.url === 'string') return b.video.url
-      if (b?.type === 'video' && typeof b?.video?.url === 'string') return b.video.url
-      if (typeof b?.url === 'string') return b.url
-    }
-  }
-  return null
-}
-
 export class VideoGenerationService {
   static async generateWithOpenAI(userId: string, input: VideoGenerationInput): Promise<VideoGenerationResult> {
     const defaults = await getVideoDefaults()


### PR DESCRIPTION
Summary
- Display locally saved videos in chat instead of expiring provider URLs.
- Enrich GET /api/v1/videos/sora2/{id}/status to include a saved local URL/fileId when available.
- Update VideoJob to use the status URL (local-first), finalize only when needed.
- Update ChatMessages to ignore remote video URLs and render via VideoJob/local asset.
- Remove temporary /api/v1/videos/sora2/by-job/{id} endpoint.

Implementation Details
- app/api/v1/videos/sora2/[id]/status/route.ts: now queries the file table by meta.jobId for the current user and, if found, returns { url, fileId } pointing to the local /files/... path. Swagger docs maintained.
- components/ai/video.tsx (VideoJob): polls status, immediately uses data.url if present; otherwise finalizes and then uses the returned local URL. Error handling preserved.
- components/chat/chat-messages.tsx: prefers local URLs ("/files/") and defers to VideoJob when only a job id or remote URL is present.
- app/files/[...path]/route.ts already handles streaming local assets with Range.
- Deleted app/api/v1/videos/sora2/by-job/[id]/route.ts after inlining its purpose into status.

Security & Validation
- All endpoints re-authorize per request via auth().
- No GET side-effects; finalization remains POST-only.
- No secrets exposed to client; client only receives local file paths served by our files route.

DX & Docs
- Swagger blocks updated/consistent for modified routes.

Testing Notes
- Start a new video generation; once job completes, VideoJob resolves a /files/... URL and the chat renders the local video. Previous 404 expiry from provider URLs should not occur anymore.

Changelog
- feat(video): local-first video display in chat via enriched status
- refactor(api): remove by-job resolver; use status for asset resolution
- fix(ui): ignore expiring remote URLs, rely on VideoJob/local asset
