### PR TITLE
Merge profile-upload-fix into dev

### DIFF
--- a/app/api/v1/users/profile-image/route.ts
+++ b/app/api/v1/users/profile-image/route.ts
@@ -63,7 +63,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const filePath = path.join(profilesDir, filename)
     await writeFile(filePath, buffer)
 
-    const url = `/data/profiles/${filename}`
+    const url = `/profiles/${filename}`
     return NextResponse.json({ url })
   } catch (error) {
     return NextResponse.json({ error: "Upload failed" }, { status: 500 })


### PR DESCRIPTION
Merges a small fix from `profile-upload-fix` into `dev`.

Highlights:
- Fix profile image URL path in POST response

Recent commits:
- fix: update profile image URL path in POST request response (1255768)

This PR targets `dev` and excludes `main`.