### PR TITLE
Ollama: show active status only in dropdown; default ps uses saved connection

### DIFF
--- a/app/api/v1/ollama/active_models/route.ts
+++ b/app/api/v1/ollama/active_models/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import * as ConnectionsRepo from '@/lib/db/connections.db'
 
 /**
  * @swagger
@@ -29,8 +30,9 @@ import { NextRequest, NextResponse } from 'next/server'
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
-    const base = (searchParams.get('baseUrl') || 'http://localhost:11434').trim()
-    const apiKey = searchParams.get('apiKey')
+    const providerConn = await ConnectionsRepo.getProviderConnection('ollama').catch(() => null)
+    const base = (searchParams.get('baseUrl') || providerConn?.baseUrl || 'http://localhost:11434').trim()
+    const apiKey = searchParams.get('apiKey') || providerConn?.apiKey || undefined
 
     // Validate URL format
     try { new URL(base) } catch {

--- a/components/chat/model-selector.tsx
+++ b/components/chat/model-selector.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useMemo } from "react"
+import { useState, useEffect, useMemo, useRef } from "react"
 import { useSearchParams } from "next/navigation"
 import { Check, ChevronsUpDown, Cpu, Link as LinkIcon, MoreHorizontal, PanelLeft } from "lucide-react"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
@@ -40,6 +40,8 @@ interface ModelSelectorProps {
 export function ModelSelector({ selectedModelId, onModelSelect, models = [], currentUserId }: ModelSelectorProps) {
   const [open, setOpen] = useState(false)
   const [userSelectedModel, setUserSelectedModel] = useState<Model | null>(null)
+  const [ollamaActiveNames, setOllamaActiveNames] = useState<Set<string>>(new Set())
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const { pinnedIds, pin, unpin } = usePinnedModels(currentUserId, { allModels: models })
   const { setOpenMobile } = useSidebar()
   const searchParams = useSearchParams()
@@ -80,6 +82,26 @@ export function ModelSelector({ selectedModelId, onModelSelect, models = [], cur
   }
 
   const isOllamaActive = (model: Model): boolean => {
+    // Prefer live data from /api/v1/ollama/active_models if available
+    if (ollamaActiveNames.size > 0) {
+      const normalize = (v: string) => v.trim().toLowerCase()
+      const tokens = new Set<string>()
+      tokens.add(normalize(model.name))
+      const providerId = typeof (model as unknown as { providerId?: unknown }).providerId === 'string'
+        ? (model as unknown as { providerId?: string }).providerId
+        : undefined
+      if (providerId) {
+        tokens.add(normalize(providerId))
+        const suffix = providerId.split('/').pop() || providerId
+        tokens.add(normalize(suffix))
+        tokens.add(normalize((suffix.split(':')[0] || suffix)))
+      }
+      for (const t of tokens) {
+        if (ollamaActiveNames.has(t) || ollamaActiveNames.has(t.split(':')[0])) return true
+      }
+      return false
+    }
+    // Fallback to meta flag if present
     return Boolean(model.meta?.details?.runtime_active)
   }
 
@@ -121,6 +143,56 @@ export function ModelSelector({ selectedModelId, onModelSelect, models = [], cur
       onModelSelect?.(found)
     }
   }, [searchParams, activeModels, onModelSelect, userSelectedModel])
+
+  // Fetch active Ollama models and maintain a set of active names (normalized)
+  useEffect(() => {
+    let aborted = false
+    const normalize = (v: string) => v.trim().toLowerCase()
+
+    const fetchActive = async () => {
+      try {
+        const res = await fetch('/api/v1/ollama/active_models', { method: 'GET', cache: 'no-store' })
+        if (!res.ok) {
+          setOllamaActiveNames(new Set())
+          return
+        }
+        const raw: unknown = await res.json().catch(() => null)
+        const next = new Set<string>()
+        if (raw && typeof raw === 'object' && raw !== null) {
+          const modelsArr = Array.isArray((raw as any).models) ? (raw as any).models : []
+          for (const item of modelsArr) {
+            if (!item || typeof item !== 'object') continue
+            const name: unknown = (item as any).name ?? (item as any).model
+            if (typeof name === 'string' && name.trim()) {
+              next.add(normalize(name))
+              next.add(normalize(name.split(':')[0]))
+              const suffix = name.split('/').pop() || name
+              next.add(normalize(suffix))
+              next.add(normalize((suffix.split(':')[0] || suffix)))
+            }
+          }
+        }
+        if (!aborted) setOllamaActiveNames(next)
+      } catch {
+        if (!aborted) setOllamaActiveNames(new Set())
+      }
+    }
+
+    // Initial fetch
+    fetchActive()
+
+    // Lightweight polling
+    if (pollRef.current) clearInterval(pollRef.current)
+    pollRef.current = setInterval(fetchActive, 10000)
+
+    return () => {
+      aborted = true
+      if (pollRef.current) {
+        clearInterval(pollRef.current)
+        pollRef.current = null
+      }
+    }
+  }, [])
 
   const handlePinModelById = async (modelId: string) => { await pin(modelId) }
   const handleUnpinModelById = async (modelId: string) => { await unpin(modelId) }
@@ -168,9 +240,6 @@ export function ModelSelector({ selectedModelId, onModelSelect, models = [], cur
                           <span className="text-xs text-primary/35 font-medium">
                             {getParameterSize(selectedModel)}
                           </span>
-                        )}
-                        {isOllamaActive(selectedModel) && (
-                          <span className="inline-block h-2 w-2 rounded-full bg-green-500" title="Active" />
                         )}
                       </div>
                     ) : (


### PR DESCRIPTION
Summary
- Remove green "active" dot from the selected model button; keep it visible only in the dropdown entries.
- Add live detection of active Ollama models via /api/v1/ollama/active_models.
- Make the active_models API default to the saved Ollama connection (baseUrl/apiKey) when not provided.

Details
- UI (components/chat/model-selector.tsx):
  - Fetch /api/v1/ollama/active_models and normalize names (handles tags/suffixes) to determine runtime activity.
  - Display the green dot only for each model item in the dropdown; not on the trigger button.
  - Lightweight polling every 10s; falls back to meta.details.runtime_active if API is unavailable.
- API (app/api/v1/ollama/active_models/route.ts):
  - Use ConnectionsRepo.getProviderConnection('ollama') as default when baseUrl/apiKey are not provided.
  - Preserve query param overrides and status/error handling.

Security & Docs
- No secrets exposed to clients; API reads server-side connection.
- Swagger annotations remain and still surface under /swagger.

Testing
- Verified the green dot appears only within the dropdown list for running Ollama models.
- Tested against local Ollama (default http://localhost:11434) and with a saved connection.

Changelog
- components/chat/model-selector.tsx
- app/api/v1/ollama/active_models/route.ts